### PR TITLE
Update identicon.gemspec

### DIFF
--- a/identicon.gemspec
+++ b/identicon.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
 	s.executables		= s.files.grep(%r{^bin/}) { |file| File.basename(file) }
 	s.require_paths	= ["lib"]
 
-	s.add_dependency	"chunky_png", "~> 1.2.8"
+	s.add_dependency	"chunky_png"
 end


### PR DESCRIPTION
- chunky_png works on over 1.3 so removed version restriction.
